### PR TITLE
adding edit profile ui

### DIFF
--- a/client/src/components/EditProfile/EditForm/EditForm.tsx
+++ b/client/src/components/EditProfile/EditForm/EditForm.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import TextField from '@material-ui/core/TextField';
+import useStyles from './useStyles';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+
+const EditForm = () => {
+  const classes = useStyles();
+
+  const [input, setInput] = useState({
+    firstName: '',
+    lastName: '',
+    gender: '',
+    birthday: '',
+    email: '',
+    phone: '',
+    address: '',
+    description: '',
+  });
+
+  const handleChange = (e: any) => {
+    const { name, value } = e.target;
+    setInput((oldState) => {
+      return { ...oldState, [name]: value };
+    });
+  };
+
+  const handleSubmit = (e: any) => {
+    e.preventDefault();
+    console.log('submitted');
+  };
+
+  return (
+    <div>
+      <Grid item xs>
+        <Typography className={classes.welcome} component="h1" variant="h5">
+          Edit Profile
+        </Typography>
+      </Grid>
+      <form onSubmit={handleSubmit} className={classes.form}>
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>first name</Typography>}
+          type="text"
+          name="firstName"
+          value={input.firstName}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>last name</Typography>}
+          type="text"
+          name="lastName"
+          value={input.lastName}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>birthday</Typography>}
+          type="text"
+          name="birthday"
+          value={input.birthday}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>gender</Typography>}
+          type="text"
+          name="gender"
+          value={input.gender}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>email</Typography>}
+          type="text"
+          name="email"
+          value={input.email}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>phone</Typography>}
+          type="text"
+          name="phone"
+          value={input.phone}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>address</Typography>}
+          type="text"
+          name="address"
+          value={input.address}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <TextField
+          fullWidth
+          className={classes.inputs}
+          label={<Typography className={classes.label}>description</Typography>}
+          type="text"
+          name="description"
+          value={input.description}
+          onChange={handleChange}
+          variant="outlined"
+        />
+        <Box textAlign="center" className={classes.submitDiv}>
+          <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
+            save
+          </Button>
+        </Box>
+      </form>
+    </div>
+  );
+};
+
+export default EditForm;

--- a/client/src/components/EditProfile/EditForm/useStyles.ts
+++ b/client/src/components/EditProfile/EditForm/useStyles.ts
@@ -1,0 +1,41 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    width: '100%', // Fix IE 11 issue.
+    marginTop: theme.spacing(2),
+  },
+  welcome: {
+    paddingBottom: 20,
+  },
+  label: {
+    fontSize: 17,
+    color: 'rgb(0,0,0,0.4)',
+    paddingLeft: '5px',
+  },
+  inputs: {
+    margin: '1rem auto',
+    height: '2rem',
+    padding: '5px',
+  },
+  forgot: {
+    paddingRight: 10,
+  },
+  submitDiv: {
+    marginTop: theme.spacing(5),
+  },
+  submit: {
+    padding: 10,
+    width: 160,
+    height: 56,
+    borderRadius: theme.shape.borderRadius,
+    borderStyle: 'none',
+    margin: '0 auto',
+    fontSize: 16,
+    backgroundColor: '#f14140',
+    fontWeight: 'bold',
+    color: theme.palette.secondary.main,
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/EditProfile/EditMenu.tsx
+++ b/client/src/components/EditProfile/EditMenu.tsx
@@ -6,6 +6,7 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Paper from '@material-ui/core/Paper';
 import { useState, ChangeEvent } from 'react';
+import EditForm from './EditForm/EditForm';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -24,11 +25,7 @@ function TabPanel(props: TabPanelProps) {
       aria-labelledby={`vertical-tab-${index}`}
       {...other}
     >
-      {value === index && (
-        <Box p={3}>
-          <Typography>{children}</Typography>
-        </Box>
-      )}
+      {value === index && <Box p={10}>{children}</Box>}
     </div>
   );
 }
@@ -68,7 +65,7 @@ const EditMenu = (): JSX.Element => {
       </Grid>
       <Grid item xs={6} md={6} lg={6} component={Paper} className={classes.tabComponents}>
         <TabPanel value={value} index={0}>
-          Edit Profile Placeholder
+          <EditForm />
         </TabPanel>
         <TabPanel value={value} index={1}>
           Profile Photo Placeholder

--- a/client/src/components/EditProfile/useStyles.ts
+++ b/client/src/components/EditProfile/useStyles.ts
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     minHeight: '100vh',
     '& .MuiInput-underline:before': {
@@ -15,12 +15,14 @@ const useStyles = makeStyles(() => ({
     justifyContent: 'flex-start',
     alignItems: 'center',
     height: 224,
+    position: 'relative',
   },
   tabs: {
     borderRight: 1,
     borderColor: 'divider',
   },
   tabComponents: {
+    marginTop: theme.spacing(15),
     flexGrow: 2,
   },
 }));

--- a/server/sample.env
+++ b/server/sample.env
@@ -1,3 +1,0 @@
-JWT_SECRET=
-MONGO_URI=
-TEAM_NAMES=Bonnie,Sina


### PR DESCRIPTION
This PR is in relation to issue #23 

### What this PR does (required):
- Added UI for profile edit page for user and controlled inputs

### Screenshots / Videos (front-end only):
![image](https://user-images.githubusercontent.com/37169222/142350858-67b75ffe-8573-4f0e-8195-02a70966073c.png)


### Any information needed to test this feature (required):
- Click the user avatar on the top right corner of the screen, and click 'profile'
- Navigate to Edit Profile from the tab

### Any issues with the current functionality (optional):
- Type checking with the React components - using typescript features
- Missing separate input field for date of birth for the user with possible drop down options
- No input validation 
- Does not link the submission with the server side. 


